### PR TITLE
chore: Experiment with auto publish gem starter workflow

### DIFF
--- a/.github/workflow-templates/auto-publish-gem-release.properties.json
+++ b/.github/workflow-templates/auto-publish-gem-release.properties.json
@@ -1,0 +1,12 @@
+{
+  "name": "Auto Publish Gem Release",
+  "description": "Publish Ruby gem on release to GitHub Packages",
+  "iconName": "octicon ruby",
+  "categories": [
+    "Ruby",
+    "continuous-integration"
+  ],
+  "filePatterns": [
+    ".*\\.gemspec$"
+  ]
+}

--- a/.github/workflow-templates/auto-publish-gem-release.yml
+++ b/.github/workflow-templates/auto-publish-gem-release.yml
@@ -1,0 +1,21 @@
+name: Publish Gem Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - uses: planningcenter/gh-action-publish-internal-gem
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is just an experiment for now. I'm trying to see if these starter workflows can be a key part of making our GitHub actions more discoverable, including details about how you a team might want to use them.

I followed along with the GitHub guide[^1] for creating these "starter workflows" that are private to our org.

The workflow can be copied via the GitHub web UI for any repo in our org, and the included metadata helps GitHub suggest certain workflows and organize them based on the repo trying to add a workflow.

[^1]: https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization