### PR TITLE
Workflows: Tweak publish-gem-release and create new update-action-tags

### DIFF
--- a/workflow-templates/publish-gem-release.properties.json
+++ b/workflow-templates/publish-gem-release.properties.json
@@ -1,6 +1,6 @@
 {
-  "name": "Auto Publish Gem Release",
-  "description": "Publish Ruby gem on release to GitHub Packages",
+  "name": "Publish Gem Release",
+  "description": "Publish Ruby gem to GitHub Packages for new releases",
   "iconName": "octicon ruby",
   "categories": [
     "Ruby",

--- a/workflow-templates/publish-gem-release.yml
+++ b/workflow-templates/publish-gem-release.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - uses: planningcenter/gh-action-publish-internal-gem
+      - uses: planningcenter/gh-action-publish-internal-gem@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/update-action-tags.properties.json
+++ b/workflow-templates/update-action-tags.properties.json
@@ -1,0 +1,11 @@
+{
+  "name": "Update GitHub Action Tags",
+  "description": "Update major & major.minor tags automatically for new releases",
+  "iconName": "octicon mark-github",
+  "categories": [
+    "continuous-integration"
+  ],
+  "filePatterns": [
+    "^action.yml$"
+  ]
+}

--- a/workflow-templates/update-action-tags.yml
+++ b/workflow-templates/update-action-tags.yml
@@ -1,0 +1,15 @@
+name: Update GitHub Action Tags
+
+on:
+  push:
+    tags:
+      - 'v([0-9]+)\.([0-9]+)\.([0-9]+)'
+
+jobs:
+  update-action-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update Semver Tags
+        uses: tchupp/actions-update-semver-tags@v1


### PR DESCRIPTION
Getting closer to something actually useful with these workflows:

1. Tweaked the name of the existing Publish Gem Release workflow and use a tag reference for the action
2. Created new action for creating & updating tags for GitHub Actions (more details in commit)