### PR TITLE
⌨️ Update `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @planningcenter/engineering-leads
+* @planningcenter/api


### PR DESCRIPTION
Once upon a time, this was `OWNED` by the ELs. Then they weren't a thing anymore. Then the GitHub team actually went away. Let's make the API team the `CODEOWNERS` of this extremely low-churn repo whose primary audience seems to be intrepid GitHub citizens who come looking for us.